### PR TITLE
Fix typo in additional operation mixin

### DIFF
--- a/lib/mixins/additional_operation_mixin.dart
+++ b/lib/mixins/additional_operation_mixin.dart
@@ -7,7 +7,7 @@ import '../ui/widgets/add_to_playlist.dart';
 import '../ui/widgets/sort_widget.dart';
 import '../utils/helper.dart';
 
-mixin AdditionalOpeartionMixin on PlaylistAlbumScreenControllerBase {
+mixin AdditionalOperationMixin on PlaylistAlbumScreenControllerBase {
   // This mixin is used to handle additional operations like sorting, searching, and performing actions on a list of songs.
   // It is used in various screens like Album, Playlist, and SongsCache.
   SortWidgetController? sortWidgetController;

--- a/lib/ui/screens/Album/album_screen_controller.dart
+++ b/lib/ui/screens/Album/album_screen_controller.dart
@@ -7,7 +7,7 @@ import 'package:harmonymusic/models/playlist.dart';
 import 'package:harmonymusic/utils/helper.dart';
 import 'package:hive/hive.dart';
 
-import '../../../mixins/additional_opeartion_mixin.dart';
+import '../../../mixins/additional_operation_mixin.dart';
 import '../../../models/media_Item_builder.dart';
 import '../Home/home_screen_controller.dart';
 import '../Library/library_controller.dart';
@@ -16,7 +16,7 @@ import '../Library/library_controller.dart';
 ///
 ///Album title,image,songs
 class AlbumScreenController extends PlaylistAlbumScreenControllerBase
-    with AdditionalOpeartionMixin, GetSingleTickerProviderStateMixin {
+    with AdditionalOperationMixin, GetSingleTickerProviderStateMixin {
   final album =
       Album(title: "", browseId: "", thumbnailUrl: "", artists: []).obs;
   final isOfflineAlbum = false.obs;

--- a/lib/ui/screens/Playlist/playlist_screen_controller.dart
+++ b/lib/ui/screens/Playlist/playlist_screen_controller.dart
@@ -12,7 +12,7 @@ import 'package:hive/hive.dart';
 import 'package:path_provider/path_provider.dart' as path_provider;
 
 import '../../../base_class/playlist_album_screen_con_base.dart';
-import '../../../mixins/additional_opeartion_mixin.dart';
+import '../../../mixins/additional_operation_mixin.dart';
 import '../../../models/album.dart' show Album;
 import '../../../models/media_Item_builder.dart';
 import '../../../models/playlist.dart';
@@ -25,7 +25,7 @@ import '../Library/library_controller.dart';
 ///
 ///Playlist title,image,songs
 class PlaylistScreenController extends PlaylistAlbumScreenControllerBase
-    with AdditionalOpeartionMixin, GetSingleTickerProviderStateMixin {
+    with AdditionalOperationMixin, GetSingleTickerProviderStateMixin {
   final MusicServices _musicServices = Get.find<MusicServices>();
   final playlist = Playlist(
     title: "",


### PR DESCRIPTION
## Summary
- rename `additional_opeartion_mixin.dart` to `additional_operation_mixin.dart`
- rename `AdditionalOpeartionMixin` to `AdditionalOperationMixin`
- update imports in playlist and album controllers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68764ff22b6083329f90d0cc3b5f6344