### PR TITLE
Fix typo in update flag file

### DIFF
--- a/lib/utils/update_check_flag_file.dart
+++ b/lib/utils/update_check_flag_file.dart
@@ -1,4 +1,4 @@
-// this file is intended to disbale update check for F-Droid build
+// this file is intended to disable update check for F-Droid build
 // GitHub released apks are still be able to provide you new Version notification (will build locally after enabling this flag)
 // If you want to enable update check please enable this flag locally & build your apk
 const updateCheckFlag = false;


### PR DESCRIPTION
## Summary
- correct a typo in `lib/utils/update_check_flag_file.dart` (disbale → disable)

## Testing
- `apt-get update`
- (failed) `flutter test` *(Flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_b_68764feee6cc8332bc2f0d115dbf979f