### PR TITLE
Fix album sorting logic

### DIFF
--- a/lib/utils/helper.dart
+++ b/lib/utils/helper.dart
@@ -73,17 +73,17 @@ void sortAlbumNSingles(
 
   switch (sortType) {
     case SortType.Date:
-      compareFunction =
-          (a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase());
-      break;
-    case SortType.Name:
-    default:
       compareFunction = (a, b) {
         if (a.year == null || b.year == null) {
           return 0.compareTo(0);
         }
         return a.year!.compareTo(b.year!);
       };
+      break;
+    case SortType.Name:
+    default:
+      compareFunction =
+          (a, b) => a.title.toLowerCase().compareTo(b.title.toLowerCase());
       break;
   }
 


### PR DESCRIPTION
## Summary
- fix comparison in `sortAlbumNSingles`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68764fe2127c8332835ce8b188c9ae5b