### PR TITLE
Fix filename sanitization regex

### DIFF
--- a/lib/services/downloader.dart
+++ b/lib/services/downloader.dart
@@ -190,8 +190,11 @@ class Downloader extends GetxService {
     final dirPath = settingsScreenController.downloadLocationPath.string;
     final actualDownformat =
         requiredAudioStream.audioCodec.name.contains("mp") ? "m4a" : "opus";
-    final RegExp invalidChar =
-        RegExp(r'Container.|\/|\\|\"|\<|\>|\*|\?|\:|\!|\[|\]|\¡|\||\%');
+    // Remove characters that can invalidate the filename on most platforms
+    // Also strip the accidental "Container." text that may appear when
+    // converting widgets to string.
+    final RegExp invalidChar = RegExp(
+        r'Container\.\s?|\/|\\|\"|\<|\>|\*|\?|\:|\!|\[|\]|\¡|\||\%');
     final songTitle = "${song.title.trim()} (${song.artist?.trim()})"
         .replaceAll(invalidChar, "");
     String filePath = "$dirPath/$songTitle.$actualDownformat";


### PR DESCRIPTION
## Summary
- fix regex when creating download filenames to escape `Container.` and other characters

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68764bd393348332aaf052dfd2e570ba